### PR TITLE
Test Updates for Airline

### DIFF
--- a/Airport-API/src/main/java/com/airportAPI/rest/aircraft/Aircraft.java
+++ b/Airport-API/src/main/java/com/airportAPI/rest/aircraft/Aircraft.java
@@ -13,6 +13,7 @@ import com.airportAPI.rest.flights.Flight;
 @Entity
 @Table(name = "aircraft")
 public class Aircraft {
+    
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,7 +49,7 @@ public class Aircraft {
     @JoinColumn(name = "airline_id")
     private Airline airline;
 
-    protected Aircraft() {
+    public Aircraft() {
     }
 
     public Aircraft(String tailNumber, String model, int capacity) {

--- a/Airport-API/src/test/java/entities/AirlineTest.java
+++ b/Airport-API/src/test/java/entities/AirlineTest.java
@@ -1,0 +1,38 @@
+package entities;
+
+import com.airportAPI.rest.airline.Airline;
+import com.airportAPI.rest.aircraft.Aircraft;
+import com.airportAPI.rest.flights.Flight;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AirlineTest {
+
+    Airline airline = new Airline("Air Canada", "AC");
+
+    @Test
+    @DisplayName("Constructor sets name & code")
+    public void testConstructor() {
+        Assertions.assertEquals("Air Canada", airline.getName());
+        Assertions.assertEquals("AC", airline.getCode());
+    }
+
+    @Test
+    public void testAddAircraft() {
+        Aircraft aircraft = new Aircraft();
+        airline.addAircraft(aircraft);
+
+        Assertions.assertTrue(airline.getAircraft().contains(aircraft));
+        Assertions.assertEquals(airline, aircraft.getAirline());
+    }
+
+    @Test
+    public void testAddFlight() {
+        Flight flight = new Flight();
+        airline.addFlight(flight);
+
+        Assertions.assertTrue(airline.getFlights().contains(flight));
+        Assertions.assertEquals(airline, flight.getAirline());
+    }
+}

--- a/Airport-API/src/test/java/services/AirlineServiceTest.java
+++ b/Airport-API/src/test/java/services/AirlineServiceTest.java
@@ -1,0 +1,106 @@
+package services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.airportAPI.rest.airline.Airline;
+import com.airportAPI.rest.airline.AirlineRepository;
+import com.airportAPI.rest.airline.AirlineService;
+
+public class AirlineServiceTest {
+
+    @Mock
+    private AirlineRepository airlineRepository;
+
+    @InjectMocks
+    private AirlineService airlineService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("getAllAirlines returns repository list")
+    public void testGetAllAirlines() {
+        List<Airline> stub = Arrays.asList(
+                new Airline("Air Canada", "AC"),
+                new Airline("WestJet", "WS")
+        );
+        when(airlineRepository.findAll()).thenReturn(stub);
+
+        List<Airline> result = airlineService.getAllAirlines();
+
+        assertEquals(stub, result);
+        verify(airlineRepository).findAll();
+    }
+
+    @Test
+    public void testGetAirlineByIdFound() {
+        Airline ac = new Airline("Air Canada", "AC");
+        ac.setId(1L);
+        when(airlineRepository.findById(1L)).thenReturn(Optional.of(ac));
+
+        Airline result = airlineService.getAirlineById(1L);
+
+        assertEquals(ac, result);
+        verify(airlineRepository).findById(1L);
+    }
+
+    @Test
+    public void testGetAirlineByIdNotFound() {
+        when(airlineRepository.findById(99L)).thenReturn(Optional.empty());
+
+        Airline result = airlineService.getAirlineById(99L);
+
+        assertNull(result);
+        verify(airlineRepository).findById(99L);
+    }
+
+    @Test
+    public void testCreateAirline() {
+        Airline ac = new Airline("Air Canada", "AC");
+        when(airlineRepository.save(ac)).thenReturn(ac);
+
+        Airline result = airlineService.createAirline(ac);
+
+        assertEquals(ac, result);
+        verify(airlineRepository).save(ac);
+    }
+
+    @Test
+    public void testUpdateAirline() {
+        Long id = 1L;
+        Airline existing = new Airline("Far", "FR");
+        existing.setId(id);
+        Airline update = new Airline("Air Canada", "AC");
+
+        when(airlineRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(airlineRepository.save(any(Airline.class))).thenAnswer(i -> i.getArgument(0));
+
+        Airline result = airlineService.updateAirline(id, update);
+
+        assertNotNull(result);
+        assertEquals("Air Canada", result.getName());
+        assertEquals("AC", result.getCode());
+        verify(airlineRepository).findById(id);
+        verify(airlineRepository).save(existing);
+    }
+
+    @Test
+    public void testDeleteAirlineById() {
+        airlineService.deleteAirlineById(1L);
+        verify(airlineRepository).deleteById(1L);
+    }
+}


### PR DESCRIPTION
- add AirlineTest – basic unit test for entity helpers (constructor, add/remove aircraft & flights)
- add AirlineServiceTest – Mockito service tests: getAll, getById, create, update, delete
- all tests compile & pass